### PR TITLE
Move info generation duplication bug

### DIFF
--- a/include/Utilities/MoveTreeDisplayHandler.hpp
+++ b/include/Utilities/MoveTreeDisplayHandler.hpp
@@ -29,4 +29,7 @@ private:
     void processNode(MoveTree::Iterator& iter_, int level_, int& row_, bool isNewLineSubvariation_ = false);
 };
 
-void printMoveInfos(const std::vector<MoveInfo>& moveInfos_);
+std::string printMoveInfos(
+    const std::vector<MoveInfo>& moveInfos_, 
+    bool printToConsole = true);
+std::string printMoveInfosGet(const std::vector<MoveInfo>& moveInfos_);

--- a/include/Utilities/MoveTreeDisplayHandler.hpp
+++ b/include/Utilities/MoveTreeDisplayHandler.hpp
@@ -8,7 +8,7 @@ struct MoveInfo
     std::string m_content = "";
     int m_row = 0; 
     int m_indentLevel = 0;
-    bool m_isInlineSubVariation = false;
+    // bool m_isInlineSubVariation = false;  -- TODO in the future 
     Move* m_movePtr = nullptr;
     std::optional<std::string> m_letterPrefix = std::nullopt;
 };
@@ -16,15 +16,17 @@ struct MoveInfo
 class MoveTreeDisplayHandler 
 {
 public:
-    explicit MoveTreeDisplayHandler(MoveTree& tree);
+    explicit MoveTreeDisplayHandler(const MoveTree& tree_);
     MoveTreeDisplayHandler() = default;
 
     std::vector<MoveInfo> generateMoveInfo();
 
 private:
-    MoveTree& m_tree;
+    const MoveTree& m_tree;
     std::vector<MoveInfo> m_moveInfos;
 
     void processNodeRec(MoveTree::Iterator& iter_, int level_, int& row_, bool isNewLineSubvariation_ = false);
     void processNode(MoveTree::Iterator& iter_, int level_, int& row_, bool isNewLineSubvariation_ = false);
 };
+
+void printMoveInfos(const std::vector<MoveInfo>& moveInfos_);

--- a/src/Utilities/MoveTreeDisplayHandler.cpp
+++ b/src/Utilities/MoveTreeDisplayHandler.cpp
@@ -100,10 +100,11 @@ void MoveTreeDisplayHandler::processNodeRec(
 
         // after the loop, goToGrandChild(0) and increase row if 
         // main line stretches after.
-        if (iter_.goToGrandChild(0))
+        MoveTree::Iterator temp_iter = iter_; 
+        if (temp_iter.goToGrandChild(0))
         {
             ++row_;
-            processNodeRec(iter_, level_, row_);
+            processNodeRec(temp_iter, level_, row_);
         }
     }
 }

--- a/src/Utilities/MoveTreeDisplayHandler.cpp
+++ b/src/Utilities/MoveTreeDisplayHandler.cpp
@@ -154,3 +154,44 @@ void printMoveInfos(const std::vector<MoveInfo>& moveInfos_)
     }
     std::cout << std::endl;
 }
+
+std::string printMoveInfos(const std::vector<MoveInfo>& moveInfos_, bool printToConsole) 
+{
+    std::ostringstream oss;
+    int currentRow = -1; 
+    bool isFirstMoveInSubvariation = true;
+
+    for (const auto& info : moveInfos_) 
+    {
+        if (info.m_row != currentRow) 
+        {
+            if (currentRow != -1) oss << std::endl;
+            currentRow = info.m_row;
+            isFirstMoveInSubvariation = true;
+        }
+
+        if (isFirstMoveInSubvariation) {
+            for (int i = 0; i < 4 * (info.m_indentLevel - 1); ++i) {
+                oss << " ";
+            }
+        } else oss << " ";
+
+        if (info.m_letterPrefix.has_value()) {
+            oss << "+--- " << info.m_letterPrefix.value() << " ";
+        }
+        isFirstMoveInSubvariation = false;
+
+        oss << info.m_content;
+    }
+
+    std::string result = oss.str();
+    if (printToConsole) std::cout << result;
+
+    return result;
+}
+
+
+std::string printMoveInfosGet(const std::vector<MoveInfo>& moveInfos_)
+{
+    return printMoveInfos(moveInfos_, false);
+}

--- a/src/Utilities/MoveTreeDisplayHandler.cpp
+++ b/src/Utilities/MoveTreeDisplayHandler.cpp
@@ -27,8 +27,8 @@ namespace
     }
 }
 
-MoveTreeDisplayHandler::MoveTreeDisplayHandler(MoveTree& tree) 
-: m_tree(tree) 
+MoveTreeDisplayHandler::MoveTreeDisplayHandler(const MoveTree& tree_) 
+: m_tree(tree_) 
 {
 }
 
@@ -126,4 +126,31 @@ std::vector<MoveInfo> MoveTreeDisplayHandler::generateMoveInfo()
     
     //printMoves(m_moveInfos);
     return m_moveInfos;
+}
+
+void printMoveInfos(const std::vector<MoveInfo>& moveInfos_) 
+{
+    int currentRow = -1; 
+
+    for (const auto& info : moveInfos_) 
+    {
+        if (info.m_row != currentRow) 
+        {
+            std::cout << std::endl;
+            currentRow = info.m_row;
+        }
+
+        for (int i = 0; i < info.m_indentLevel; ++i) {
+            std::cout << " ";
+        }
+
+        if (info.m_letterPrefix.has_value()) {
+            std::cout << "+--- " << info.m_letterPrefix.value() << " ";
+        }
+
+        std::cout << info.m_content;
+
+        if (info.m_indentLevel == 0) std::cout << " ";
+    }
+    std::cout << std::endl;
 }

--- a/tests/MoveTreeDisplayHandlerTest.cpp
+++ b/tests/MoveTreeDisplayHandlerTest.cpp
@@ -46,11 +46,36 @@ BOOST_AUTO_TEST_CASE(TestSimple)
     MoveTreeManager moveTreeManager{m_board};
     const std::string PGNString = "1. e4 e5 2. d4 (2. Nf3 Nc6 3. h3) (2. Nc3)";
     moveTreeManager.initializeMoveSequenceFromPNG(PGNString);
+    const std::string expectedString = 
+        "1.e4 e5 2.d4\n"
+        "+--- A) 2.Nf3 Nc6 3.h3\n"
+        "+--- B) 2.Nc3";
 
     const MoveTree& moveTree = moveTreeManager.getMoves();
     MoveTreeDisplayHandler handler{moveTree};
     std::vector<MoveInfo> actualMovesInfo = handler.generateMoveInfo();
-    printMoveInfos(actualMovesInfo);
+    BOOST_CHECK_EQUAL(printMoveInfosGet(actualMovesInfo), expectedString);
+}
+
+BOOST_AUTO_TEST_CASE(TestBlackSubvariations)
+{
+    MoveTreeManager moveTreeManager{m_board};
+    const std::string PGNString = 
+        "1. e4 e5 (1... d5 2. exd5 Nf6 (2... Qxd5 3. "
+        "Qg4 Qxg2 (3... Nf6)) (2... Bf5 3. Bd3 Bxd3 (3... Bg4)))";
+    moveTreeManager.initializeMoveSequenceFromPNG(PGNString);
+    const std::string expectedString = 
+        "1.e4 e5\n"
+        "+--- A) 1...d5 2.exd5 Nf6\n"
+        "    +--- A1) 2...Qxd5 3.Qg4 Qxg2\n"
+        "        +--- A1,1) 3...Nf6\n"
+        "    +--- A2) 2...Bf5 3.Bd3 Bxd3\n"
+        "        +--- A2,1) 3...Bg4";
+
+    const MoveTree& moveTree = moveTreeManager.getMoves();
+    MoveTreeDisplayHandler handler{moveTree};
+    std::vector<MoveInfo> actualMovesInfo = handler.generateMoveInfo();
+    BOOST_CHECK_EQUAL(printMoveInfosGet(actualMovesInfo), expectedString);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/MoveTreeDisplayHandlerTest.cpp
+++ b/tests/MoveTreeDisplayHandlerTest.cpp
@@ -41,4 +41,16 @@ BOOST_AUTO_TEST_CASE(TestBlackInitialNumberOfMovesAvailable)
     moveTreeManager.initializeMoveSequenceFromPNG(myPNG);
 }
 
+BOOST_AUTO_TEST_CASE(TestSimple)
+{
+    MoveTreeManager moveTreeManager{m_board};
+    const std::string PGNString = "1. e4 e5 2. d4 (2. Nf3 Nc6 3. h3) (2. Nc3)";
+    moveTreeManager.initializeMoveSequenceFromPNG(PGNString);
+
+    const MoveTree& moveTree = moveTreeManager.getMoves();
+    MoveTreeDisplayHandler handler{moveTree};
+    std::vector<MoveInfo> actualMovesInfo = handler.generateMoveInfo();
+    printMoveInfos(actualMovesInfo);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Issue was that we were not going back with the call
```c++
if (iter_.goToGrandChild(0))
{
    ++row_;
    processNodeRec(iter_, level_, row_);
}
```
It suffices to make a local iterator copy and traverse using that one. 